### PR TITLE
fix: remove duplicate fs require to avoid redeclaration on deploy

### DIFF
--- a/bridge/server.js
+++ b/bridge/server.js
@@ -2,7 +2,6 @@ const express = require('express');
 const { exec } = require('child_process');
 const fs = require('fs');
 const path = require('path');
-const fs = require('fs');
 
 const app = express();
 const port = process.env.PORT || 3002;


### PR DESCRIPTION
Remove duplicate `require('fs')` in `bridge/server.js` to prevent SyntaxError on deploys (Identifier 'fs' has already been declared). This is a small fix to ensure Render/Netlify deployments start correctly.